### PR TITLE
whitelist data attr

### DIFF
--- a/class-fieldmanager-gallery.php
+++ b/class-fieldmanager-gallery.php
@@ -101,6 +101,12 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 			wp_enqueue_script( 'fm_gallery', $this->plugin_url . 'js/fieldmanager-gallery.js', array( 'jquery' ) );
 			self::$has_registered_gallery = True;
 		}
+
+		add_filter( 'wp_kses_allowed_html', function( $allowed_html ) {
+			$allowed_html['div']['data-id'] = true;
+			return $allowed_html;
+		} );
+
 		parent::__construct( $label, $options );
 	}
 

--- a/class-fieldmanager-gallery.php
+++ b/class-fieldmanager-gallery.php
@@ -107,7 +107,7 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 		 * to expose gallery item IDs to the JS.
 		 */
 		add_filter( 'wp_kses_allowed_html', function( $allowed_html ) {
-			$allowed_html['div']['data-id'] = true;
+			$allowed_html['div']['data-fieldmanager-item-id'] = true;
 			return $allowed_html;
 		} );
 
@@ -154,7 +154,7 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 			if ( is_numeric( $value ) && $value > 0 ) {
 
 				$attachment = get_post( $value );
-				$out = '<div class="gallery-item" data-id="' . esc_attr( $value ) . '">';
+				$out = '<div class="gallery-item" data-fieldmanager-item-id="' . esc_attr( $value ) . '">';
 
 				if ( strpos( $attachment->post_mime_type, 'image/' ) === 0 ) {
 

--- a/class-fieldmanager-gallery.php
+++ b/class-fieldmanager-gallery.php
@@ -102,6 +102,10 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 			self::$has_registered_gallery = True;
 		}
 
+		/**
+		 * Whitelist the data attribute used
+		 * to expose gallery item IDs to the JS.
+		 */
 		add_filter( 'wp_kses_allowed_html', function( $allowed_html ) {
 			$allowed_html['div']['data-id'] = true;
 			return $allowed_html;

--- a/js/fieldmanager-gallery.js
+++ b/js/fieldmanager-gallery.js
@@ -21,7 +21,7 @@ var sortableCollection = function() {
 				var val = [];
 
 				$wrapper.children('.gallery-item').each( function() {
-					val.push( $(this).data('id') );
+					val.push( $(this).data('fieldmanager-item-id') );
 				} );
 
 				$input.val( val.join(',') );
@@ -179,7 +179,7 @@ $( document ).on( 'click', '.fm-gallery-button', function( event ) {
 
 			var galleryItem = $( '<div />', {
 				class: 'gallery-item',
-				'data-id': attachment.id,
+				'data-fieldmanager-item-id': attachment.id,
 			} );
 
 			galleryItems.push( galleryItem );


### PR DESCRIPTION
Pretty serious bug... Gallery images can vanish on update.

To reproduce: Create gallery and publish a post. Then try to edit the order, and hit update. All the data is lost!

Problem: The IDs are passed as data attributes. But this is stripped by `wp_kses_post`

Solution: Whitelist `data-id`
