### PR TITLE
Don't enqueue Fieldmanager Gallery's JS/CSS on the front end

### DIFF
--- a/class-fieldmanager-gallery.php
+++ b/class-fieldmanager-gallery.php
@@ -97,9 +97,11 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 			wp_enqueue_media( $args ); // generally on post pages this will not have an impact.
 		} );
 		if ( !self::$has_registered_gallery ) {
-			wp_enqueue_style( 'fm_gallery', $this->plugin_url . 'css/fieldmanager-gallery.css', array() );
-			wp_enqueue_script( 'fm_gallery', $this->plugin_url . 'js/fieldmanager-gallery.js', array( 'jquery' ) );
-			self::$has_registered_gallery = True;
+			add_action( 'admin_enqueue_scripts', function() {
+				wp_enqueue_style( 'fm_gallery', $this->plugin_url . 'css/fieldmanager-gallery.css', array() );
+				wp_enqueue_script( 'fm_gallery', $this->plugin_url . 'js/fieldmanager-gallery.js', array( 'jquery' ) );
+				self::$has_registered_gallery = True;
+			} );
 		}
 		parent::__construct( $label, $options );
 	}


### PR DESCRIPTION
The `css/fieldmanager-gallery.css` and `js/fieldmanager-gallery.js` files get enqueued on the front end. Let's not.