### PR TITLE
Fmg enhancements

### DIFF
--- a/class-fieldmanager-gallery.php
+++ b/class-fieldmanager-gallery.php
@@ -20,6 +20,12 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 
 	/**
 	 * @var string
+	 * Empty gallery button Label
+	 */
+	public $empty_gallery_label;
+
+	/**
+	 * @var string
 	 * Button label in the gallery modal popup
 	 */
 	public $modal_button_label;
@@ -103,6 +109,16 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 				self::$has_registered_gallery = True;
 			} );
 		}
+
+		/**
+		 * Whitelist the data attribute used
+		 * to expose gallery item IDs to the JS.
+		 */
+		add_filter( 'wp_kses_allowed_html', function( $allowed_html ) {
+			$allowed_html['div']['data-fieldmanager-item-id'] = true;
+			return $allowed_html;
+		} );
+
 		parent::__construct( $label, $options );
 	}
 
@@ -146,7 +162,7 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 			if ( is_numeric( $value ) && $value > 0 ) {
 
 				$attachment = get_post( $value );
-				$out = '<div class="gallery-item" data-id="' . esc_attr( $value ) . '">';
+				$out = '<div class="gallery-item" data-fieldmanager-item-id="' . esc_attr( $value ) . '">';
 
 				if ( strpos( $attachment->post_mime_type, 'image/' ) === 0 ) {
 
@@ -175,8 +191,9 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 		$input_value = implode( ',', $values );
 
 		return sprintf(
-			'<input type="button" class="fm-gallery-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" data-collection="%9$s" />
-			<input type="hidden" name="%2$s" value="%4$s" class="fm-element fm-gallery-id" />
+			'<input type="button" class="fm-gallery-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" data-collection="%9$s" />' .
+			( $this->collection ? ' <input type="button" class="fm-gallery-empty button-secondary fm-incrementable' . ( empty( $input_value ) ? ' button-disabled' : '' ) . '" value="%10$s" />' : '' ) .
+			'<input type="hidden" name="%2$s" value="%4$s" class="fm-element fm-gallery-id" />
 			<div class="gallery-wrapper">%5$s</div>
 			<script type="text/javascript">
 			var fm_preview_size = fm_preview_size || [];
@@ -190,7 +207,8 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 			json_encode( $this->preview_size ),
 			esc_attr( $this->modal_title ),
 			esc_attr( $this->modal_button_label ),
-			intval( $this->collection )
+			intval( $this->collection ),
+			esc_attr( $this->empty_gallery_label )
 		);
 	}
 

--- a/js/fieldmanager-gallery.js
+++ b/js/fieldmanager-gallery.js
@@ -21,7 +21,7 @@ var sortableCollection = function() {
 				var val = [];
 
 				$wrapper.children('.gallery-item').each( function() {
-					val.push( $(this).data('id') );
+					val.push( $(this).data('fieldmanager-item-id') );
 				} );
 
 				$input.val( val.join(',') );
@@ -42,8 +42,14 @@ var sortableCollection = function() {
 $( document ).ready( sortableCollection );
 $( document ).on( 'fieldmanager_gallery_preview', sortableCollection );
 
-$( document ).on( 'click', '.fm-gallery-remove', function(e) {
+$( document ).on( 'click', '.fm-gallery-remove, .fm-gallery-empty', function(e) {
 	e.preventDefault();
+
+	// Disable empty button
+	if ( $(this).hasClass('fm-gallery-empty') ) {;
+		$(this).addClass('button-disabled');
+	}
+
 	var parent = $(this).parents( '.fm-item.fm-gallery' );
 	parent.find( '.fm-gallery-id' ).val('');
 	parent.find( '.gallery-wrapper' ).html( '' );
@@ -162,6 +168,10 @@ $( document ).on( 'click', '.fm-gallery-button', function( event ) {
 		if ( ! $el.data('collection') ) {
 			attachments = fm_gallery_frame[ $el.attr('id') ].state().get('selection');
 		}
+		// Update empty gallery button state
+		else {
+			$el.siblings('.fm-gallery-empty').removeClass('button-disabled');
+		}
 
 		var ids = [],
 		    galleryItems = [];
@@ -180,7 +190,7 @@ $( document ).on( 'click', '.fm-gallery-button', function( event ) {
 
 			var galleryItem = $( '<div />', {
 				'class': 'gallery-item',
-				'data-id': attachment.id,
+				'data-fieldmanager-item-id': attachment.id,
 			} );
 
 			galleryItems.push( galleryItem );
@@ -221,6 +231,13 @@ $( document ).on( 'click', '.fm-gallery-button', function( event ) {
 	// When an image is selected, run a callback.
 	fm_gallery_frame[ $el.attr('id') ].on( 'select', mediaFrameHandleSelect );
 	fm_gallery_frame[ $el.attr('id') ].on( 'update', mediaFrameHandleSelect );
+
+	// When closing modal, deletes frame by assuring always sync with the preview (data collection only)
+	fm_gallery_frame[ $el.attr('id') ].on( 'close', function(e) {
+		if ( $el.data('collection') ) {
+			delete fm_gallery_frame[ $el.attr('id') ];
+		}
+	} );
 
 	fm_gallery_frame[ $el.attr('id') ].open();
 


### PR DESCRIPTION
This PR adds some fix and enhamcements

1. Gallery disappearing. I merged the fixes from  https://github.com/fusioneng/fieldmanager-gallery/pull/6 that live in a branch (vip-fixed) that is some commits behind master. 

2. Added `empty_gallery_button` (only for collections) in order to remove a gallery. This could solve the issue https://github.com/fusioneng/fieldmanager-gallery/issues/11

3. Fixed the sync with the gallery preview and modal media frame. Not too a serious bug but annoying.

To reproduce: 

- Attach gallery -> create gallery (with some images) -> insert gallery.
If we don't save (draft/publish) the post or don't drag&drop on the preview, by clicking on attach gallery button again, the modal media window always shows a new empty gallery.

- For an existing gallery, open the modal media and sort/delete items without applies changes (for example by clicking on 'X' or 'Cancell gallery'). 
If we don't save (draft/publish) the post or don't drag&drop on the preview, next time that you re-open the modal, the items shown don't match wtih those in the preview.

With the fix, when closing modal, the frame is deleted by assuring always sync with the preview.
